### PR TITLE
Support iterators over non-owning pointer types

### DIFF
--- a/feature_tests/cpp/include/diplomat_runtime.hpp
+++ b/feature_tests/cpp/include/diplomat_runtime.hpp
@@ -449,9 +449,10 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
 template<class T>
 fn_traits(T) -> fn_traits<T>;
 
-// Trait for extracting inner types from either std::optional or std::unique_ptr.
-// These are the two potential types returned by next() functions
-template<typename T> struct inner { using type = T; };
+// Trait for extracting inner types from either T*, std::optional, or std::unique_ptr.
+// These are the three potential types returned by next() functions
+template<typename T> struct inner { /* only T*, std::optional, and std::unique_ptr are supported */ };
+template<typename T> struct inner<T*> { using type = T; };
 template<typename T> struct inner<std::unique_ptr<T>> { using type = T; };
 template<typename T> struct inner<std::optional<T>>{ using type = T; };
 

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterable.d.hpp
@@ -12,6 +12,8 @@
 #include "../diplomat_runtime.hpp"
 
 namespace ns {
+namespace capi { struct RenamedOpaqueIterable; }
+class RenamedOpaqueIterable;
 namespace capi { struct RenamedOpaqueIterator; }
 class RenamedOpaqueIterator;
 }
@@ -26,6 +28,8 @@ namespace capi {
 namespace ns {
 class RenamedOpaqueIterable {
 public:
+
+  inline static std::unique_ptr<ns::RenamedOpaqueIterable> new_(size_t size);
 
   inline std::unique_ptr<ns::RenamedOpaqueIterator> iter() const;
   inline diplomat::next_to_iter_helper<ns::RenamedOpaqueIterator> begin() const;

--- a/feature_tests/cpp/include/ns/RenamedOpaqueIterable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueIterable.hpp
@@ -19,6 +19,8 @@ namespace ns {
 namespace capi {
     extern "C" {
 
+    ns::capi::RenamedOpaqueIterable* namespace_OpaqueIterable_new(size_t size);
+
     ns::capi::RenamedOpaqueIterator* namespace_OpaqueIterable_iter(const ns::capi::RenamedOpaqueIterable* self);
 
     void namespace_OpaqueIterable_destroy(RenamedOpaqueIterable* self);
@@ -26,6 +28,11 @@ namespace capi {
     } // extern "C"
 } // namespace capi
 } // namespace
+
+inline std::unique_ptr<ns::RenamedOpaqueIterable> ns::RenamedOpaqueIterable::new_(size_t size) {
+    auto result = ns::capi::namespace_OpaqueIterable_new(size);
+    return std::unique_ptr<ns::RenamedOpaqueIterable>(ns::RenamedOpaqueIterable::FromFFI(result));
+}
 
 inline std::unique_ptr<ns::RenamedOpaqueIterator> ns::RenamedOpaqueIterable::iter() const {
     auto result = ns::capi::namespace_OpaqueIterable_iter(this->AsFFI());

--- a/feature_tests/cpp/include/ns/RenamedOpaqueRefIterable.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueRefIterable.d.hpp
@@ -1,0 +1,53 @@
+#ifndef ns_RenamedOpaqueRefIterable_D_HPP
+#define ns_RenamedOpaqueRefIterable_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+namespace ns {
+namespace capi { struct RenamedOpaqueRefIterable; }
+class RenamedOpaqueRefIterable;
+namespace capi { struct RenamedOpaqueRefIterator; }
+class RenamedOpaqueRefIterator;
+}
+
+
+namespace ns {
+namespace capi {
+    struct RenamedOpaqueRefIterable;
+} // namespace capi
+} // namespace
+
+namespace ns {
+class RenamedOpaqueRefIterable {
+public:
+
+  inline static std::unique_ptr<ns::RenamedOpaqueRefIterable> new_(size_t size);
+
+  inline std::unique_ptr<ns::RenamedOpaqueRefIterator> iter() const;
+  inline diplomat::next_to_iter_helper<ns::RenamedOpaqueRefIterator> begin() const;
+  inline std::nullopt_t end() const { return std::nullopt; }
+
+    inline const ns::capi::RenamedOpaqueRefIterable* AsFFI() const;
+    inline ns::capi::RenamedOpaqueRefIterable* AsFFI();
+    inline static const ns::RenamedOpaqueRefIterable* FromFFI(const ns::capi::RenamedOpaqueRefIterable* ptr);
+    inline static ns::RenamedOpaqueRefIterable* FromFFI(ns::capi::RenamedOpaqueRefIterable* ptr);
+    inline static void operator delete(void* ptr);
+private:
+    RenamedOpaqueRefIterable() = delete;
+    RenamedOpaqueRefIterable(const ns::RenamedOpaqueRefIterable&) = delete;
+    RenamedOpaqueRefIterable(ns::RenamedOpaqueRefIterable&&) noexcept = delete;
+    RenamedOpaqueRefIterable operator=(const ns::RenamedOpaqueRefIterable&) = delete;
+    RenamedOpaqueRefIterable operator=(ns::RenamedOpaqueRefIterable&&) noexcept = delete;
+    static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // ns_RenamedOpaqueRefIterable_D_HPP

--- a/feature_tests/cpp/include/ns/RenamedOpaqueRefIterable.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueRefIterable.hpp
@@ -1,0 +1,67 @@
+#ifndef ns_RenamedOpaqueRefIterable_HPP
+#define ns_RenamedOpaqueRefIterable_HPP
+
+#include "RenamedOpaqueRefIterable.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+#include "RenamedOpaqueRefIterator.hpp"
+
+
+namespace ns {
+namespace capi {
+    extern "C" {
+
+    ns::capi::RenamedOpaqueRefIterable* namespace_OpaqueRefIterable_new(size_t size);
+
+    ns::capi::RenamedOpaqueRefIterator* namespace_OpaqueRefIterable_iter(const ns::capi::RenamedOpaqueRefIterable* self);
+
+    void namespace_OpaqueRefIterable_destroy(RenamedOpaqueRefIterable* self);
+
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::unique_ptr<ns::RenamedOpaqueRefIterable> ns::RenamedOpaqueRefIterable::new_(size_t size) {
+    auto result = ns::capi::namespace_OpaqueRefIterable_new(size);
+    return std::unique_ptr<ns::RenamedOpaqueRefIterable>(ns::RenamedOpaqueRefIterable::FromFFI(result));
+}
+
+inline std::unique_ptr<ns::RenamedOpaqueRefIterator> ns::RenamedOpaqueRefIterable::iter() const {
+    auto result = ns::capi::namespace_OpaqueRefIterable_iter(this->AsFFI());
+    return std::unique_ptr<ns::RenamedOpaqueRefIterator>(ns::RenamedOpaqueRefIterator::FromFFI(result));
+}
+
+inline diplomat::next_to_iter_helper<ns::RenamedOpaqueRefIterator>ns::RenamedOpaqueRefIterable::begin() const {
+    return iter();
+}
+
+inline const ns::capi::RenamedOpaqueRefIterable* ns::RenamedOpaqueRefIterable::AsFFI() const {
+    return reinterpret_cast<const ns::capi::RenamedOpaqueRefIterable*>(this);
+}
+
+inline ns::capi::RenamedOpaqueRefIterable* ns::RenamedOpaqueRefIterable::AsFFI() {
+    return reinterpret_cast<ns::capi::RenamedOpaqueRefIterable*>(this);
+}
+
+inline const ns::RenamedOpaqueRefIterable* ns::RenamedOpaqueRefIterable::FromFFI(const ns::capi::RenamedOpaqueRefIterable* ptr) {
+    return reinterpret_cast<const ns::RenamedOpaqueRefIterable*>(ptr);
+}
+
+inline ns::RenamedOpaqueRefIterable* ns::RenamedOpaqueRefIterable::FromFFI(ns::capi::RenamedOpaqueRefIterable* ptr) {
+    return reinterpret_cast<ns::RenamedOpaqueRefIterable*>(ptr);
+}
+
+inline void ns::RenamedOpaqueRefIterable::operator delete(void* ptr) {
+    ns::capi::namespace_OpaqueRefIterable_destroy(reinterpret_cast<ns::capi::RenamedOpaqueRefIterable*>(ptr));
+}
+
+
+#endif // ns_RenamedOpaqueRefIterable_HPP

--- a/feature_tests/cpp/include/ns/RenamedOpaqueRefIterator.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueRefIterator.d.hpp
@@ -1,0 +1,47 @@
+#ifndef ns_RenamedOpaqueRefIterator_D_HPP
+#define ns_RenamedOpaqueRefIterator_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+namespace ns {
+namespace capi { struct AttrOpaque1Renamed; }
+class AttrOpaque1Renamed;
+}
+
+
+namespace ns {
+namespace capi {
+    struct RenamedOpaqueRefIterator;
+} // namespace capi
+} // namespace
+
+namespace ns {
+class RenamedOpaqueRefIterator {
+public:
+
+  inline const ns::AttrOpaque1Renamed* next();
+
+    inline const ns::capi::RenamedOpaqueRefIterator* AsFFI() const;
+    inline ns::capi::RenamedOpaqueRefIterator* AsFFI();
+    inline static const ns::RenamedOpaqueRefIterator* FromFFI(const ns::capi::RenamedOpaqueRefIterator* ptr);
+    inline static ns::RenamedOpaqueRefIterator* FromFFI(ns::capi::RenamedOpaqueRefIterator* ptr);
+    inline static void operator delete(void* ptr);
+private:
+    RenamedOpaqueRefIterator() = delete;
+    RenamedOpaqueRefIterator(const ns::RenamedOpaqueRefIterator&) = delete;
+    RenamedOpaqueRefIterator(ns::RenamedOpaqueRefIterator&&) noexcept = delete;
+    RenamedOpaqueRefIterator operator=(const ns::RenamedOpaqueRefIterator&) = delete;
+    RenamedOpaqueRefIterator operator=(ns::RenamedOpaqueRefIterator&&) noexcept = delete;
+    static void operator delete[](void*, size_t) = delete;
+};
+
+} // namespace
+#endif // ns_RenamedOpaqueRefIterator_D_HPP

--- a/feature_tests/cpp/include/ns/RenamedOpaqueRefIterator.hpp
+++ b/feature_tests/cpp/include/ns/RenamedOpaqueRefIterator.hpp
@@ -1,0 +1,56 @@
+#ifndef ns_RenamedOpaqueRefIterator_HPP
+#define ns_RenamedOpaqueRefIterator_HPP
+
+#include "RenamedOpaqueRefIterator.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+#include "AttrOpaque1Renamed.hpp"
+
+
+namespace ns {
+namespace capi {
+    extern "C" {
+
+    const ns::capi::AttrOpaque1Renamed* namespace_OpaqueRefIterator_next(ns::capi::RenamedOpaqueRefIterator* self);
+
+    void namespace_OpaqueRefIterator_destroy(RenamedOpaqueRefIterator* self);
+
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline const ns::AttrOpaque1Renamed* ns::RenamedOpaqueRefIterator::next() {
+    auto result = ns::capi::namespace_OpaqueRefIterator_next(this->AsFFI());
+    return ns::AttrOpaque1Renamed::FromFFI(result);
+}
+
+inline const ns::capi::RenamedOpaqueRefIterator* ns::RenamedOpaqueRefIterator::AsFFI() const {
+    return reinterpret_cast<const ns::capi::RenamedOpaqueRefIterator*>(this);
+}
+
+inline ns::capi::RenamedOpaqueRefIterator* ns::RenamedOpaqueRefIterator::AsFFI() {
+    return reinterpret_cast<ns::capi::RenamedOpaqueRefIterator*>(this);
+}
+
+inline const ns::RenamedOpaqueRefIterator* ns::RenamedOpaqueRefIterator::FromFFI(const ns::capi::RenamedOpaqueRefIterator* ptr) {
+    return reinterpret_cast<const ns::RenamedOpaqueRefIterator*>(ptr);
+}
+
+inline ns::RenamedOpaqueRefIterator* ns::RenamedOpaqueRefIterator::FromFFI(ns::capi::RenamedOpaqueRefIterator* ptr) {
+    return reinterpret_cast<ns::RenamedOpaqueRefIterator*>(ptr);
+}
+
+inline void ns::RenamedOpaqueRefIterator::operator delete(void* ptr) {
+    ns::capi::namespace_OpaqueRefIterator_destroy(reinterpret_cast<ns::capi::RenamedOpaqueRefIterator*>(ptr));
+}
+
+
+#endif // ns_RenamedOpaqueRefIterator_HPP

--- a/feature_tests/cpp/tests/attrs.cpp
+++ b/feature_tests/cpp/tests/attrs.cpp
@@ -3,6 +3,8 @@
 #include "../include/ns/RenamedOpaqueArithmetic.hpp"
 #include "../include/ns/RenamedAttrEnum.hpp"
 #include "../include/ns/RenamedMyIterable.hpp"
+#include "../include/ns/RenamedOpaqueIterable.hpp"
+#include "../include/ns/RenamedOpaqueRefIterable.hpp"
 #include "../include/ns/RenamedComparable.hpp"
 #include "../include/ns/RenamedVectorTest.hpp"
 #include "../include/Unnamespaced.hpp"
@@ -47,22 +49,40 @@ int main(int argc, char* argv[]) {
     simple_assert_eq("vector indexer", (*vec)[1].value(), 1.6);
     simple_assert_eq("vector indexer", (*vec)[2].has_value(), false);
 
-
     auto uintVec = std::vector<uint8_t>{ 1, 2, 3, 4 };
-    auto myIterable = ns::RenamedMyIterable::new_(diplomat::span<const uint8_t>{uintVec.data(), uintVec.size()});
-    auto myIt = myIterable->begin();
 
-    simple_assert_eq("Iteration dereference", *myIt, 1);
-    myIt++;
-    simple_assert_eq("Iteration manual increment", *myIt, 2);
+    // Iterators returning optional types
+    {
+        auto myIterable = ns::RenamedMyIterable::new_(diplomat::span<const uint8_t>{uintVec.data(), uintVec.size()});
+        auto myIt = myIterable->begin();
 
-    auto unitVecCopy = std::vector<uint8_t>();
-    for (auto element : *myIterable) {
-        unitVecCopy.push_back(element);
+        simple_assert_eq("Iteration dereference", *myIt, 1);
+        myIt++;
+        simple_assert_eq("Iteration manual increment", *myIt, 2);
+ 
+        auto unitVecCopy = std::vector<uint8_t>();
+        for (auto element : *myIterable) {
+            unitVecCopy.push_back(element);
+        }
+        simple_assert("For loop iteration", uintVec == unitVecCopy);
+        simple_assert("stl-algorithm iteration failed", std::equal(uintVec.begin(), uintVec.end(), myIterable->begin()));
     }
-    simple_assert("For loop iteration", uintVec == unitVecCopy);
 
-    simple_assert("stl-algorithm iteration failed", std::equal(uintVec.begin(), uintVec.end(), myIterable->begin()));
+    // Iterators returning opaque types
+    {
+        auto myOpaqueIterable = ns::RenamedOpaqueIterable::new_(2);
+        for (auto& element : *myOpaqueIterable) {
+            simple_assert("For loop iteration", element.method_renamed() == 77);
+        }
+    }
+
+    // Iterators returning non-owning types
+    {
+        auto myOpaqueRefIterable = ns::RenamedOpaqueRefIterable::new_(2);
+        for (auto& element : *myOpaqueRefIterable) {
+            simple_assert("For loop iteration", element.method_renamed() == 77);
+        }
+    }
 
     auto cmpA = ns::RenamedComparable::new_(0);
     auto cmpB = ns::RenamedComparable::new_(0);

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -188,6 +188,11 @@ pub mod ffi {
     struct OpaqueIterable(Vec<AttrOpaque1>);
 
     impl OpaqueIterable {
+        #[diplomat::attr(auto, constructor)]
+        pub fn new(size: usize) -> Box<Self> {
+            Box::new(Self(vec![AttrOpaque1; size]))
+        }
+
         #[diplomat::attr(auto, iterable)]
         pub fn iter<'a>(&'a self) -> Box<OpaqueIterator<'a>> {
             Box::new(OpaqueIterator(Box::new(self.0.iter().cloned())))
@@ -201,6 +206,32 @@ pub mod ffi {
         #[diplomat::attr(auto, iterator)]
         pub fn next(&'a mut self) -> Option<Box<AttrOpaque1>> {
             self.0.next().map(Box::new)
+        }
+    }
+
+    #[diplomat::opaque]
+    #[diplomat::attr(not(supports = iterators), disable)]
+    struct OpaqueRefIterable(Vec<AttrOpaque1>);
+
+    impl OpaqueRefIterable {
+        #[diplomat::attr(auto, constructor)]
+        pub fn new(size: usize) -> Box<Self> {
+            Box::new(Self(vec![AttrOpaque1; size]))
+        }
+
+        #[diplomat::attr(auto, iterable)]
+        pub fn iter<'a>(&'a self) -> Box<OpaqueRefIterator<'a>> {
+            Box::new(OpaqueRefIterator(self.0.iter()))
+        }
+    }
+
+    #[diplomat::opaque]
+    #[diplomat::attr(not(supports = iterators), disable)]
+    struct OpaqueRefIterator<'a>(std::slice::Iter<'a, AttrOpaque1>);
+    impl<'a> OpaqueRefIterator<'a> {
+        #[diplomat::attr(auto, iterator)]
+        pub fn next(&'a mut self) -> Option<&'a AttrOpaque1> {
+            self.0.next()
         }
     }
 

--- a/tool/templates/cpp/runtime.hpp.jinja
+++ b/tool/templates/cpp/runtime.hpp.jinja
@@ -395,9 +395,10 @@ template <typename Ret, typename... Args> struct fn_traits<std::function<Ret(Arg
 template<class T>
 fn_traits(T) -> fn_traits<T>;
 
-// Trait for extracting inner types from either std::optional or std::unique_ptr.
-// These are the two potential types returned by next() functions
-template<typename T> struct inner { using type = T; };
+// Trait for extracting inner types from either T*, std::optional, or std::unique_ptr.
+// These are the three potential types returned by next() functions
+template<typename T> struct inner { /* only T*, std::optional, and std::unique_ptr are supported */ };
+template<typename T> struct inner<T*> { using type = T; };
 template<typename T> struct inner<std::unique_ptr<T>> { using type = T; };
 template<typename T> struct inner<std::optional<T>>{ using type = T; };
 


### PR DESCRIPTION
We noticed that iterators returning non-owning value types such as:

```rust
#[diplomat::attr(auto, iterator)]
pub fn next(&'a mut self) -> Option<&'a T>
```

were failing to compile in C++, because this `next_to_iter_helper` expects owned `unique_ptr`'s or `optional`'s, but was being given value_types of `T*`. This created some type mismatches in `operator*` because `T*` was not properly decayed into `T` by `inner`. In fact, the base case of `inner { using type = T; }` will pretty much never work, because there is no "inner" type.

Specific compiler error: (user types replaced with `T` for clarity)

```
no viable conversion from returned value of type 'const T' to function return type 'const value_type' (aka 'const T *const')
  501 |   const value_type& operator*() const { return *_curr; }
```