### PR TITLE
Start requiring opaque_mut on mutated opaques (#1065)

### DIFF
--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -1599,7 +1599,7 @@ mod tests {
             mod ffi {
                 use std::cmp;
 
-                #[diplomat::opaque]
+                #[diplomat::opaque_mut]
                 #[diplomat::attr(auto, namespace = "should_not_show_up")]
                 struct Opaque;
 
@@ -1632,7 +1632,7 @@ mod tests {
             mod ffi {
                 use std::cmp;
 
-                #[diplomat::opaque]
+                #[diplomat::opaque_mut]
                 struct Opaque;
 
                 struct Struct {
@@ -1709,7 +1709,7 @@ mod tests {
 
                 #[diplomat::opaque]
                 struct Opaque(Vec<u8>);
-                #[diplomat::opaque]
+                #[diplomat::opaque_mut]
                 struct OpaqueIterator<'a>(std::slice::Iter<'a>);
 
 

--- a/example/src/fixed_decimal.rs
+++ b/example/src/fixed_decimal.rs
@@ -4,7 +4,7 @@ pub mod ffi {
     use diplomat_runtime::DiplomatWrite;
     use writeable::Writeable;
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     // Attr for generating mocking interface in kotlin backend to enable JVM test fakes.
     #[diplomat::attr(kotlin, generate_mocking_interface)]
     #[diplomat::rust_link(fixed_decimal::FixedDecimal, Struct)]

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -20,7 +20,7 @@ pub mod ffi {
     #[diplomat::macro_rules]
     macro_rules! create_vec {
         ($vec_name:ident contains "hello"; [$ty:ident]) => {
-            #[diplomat::opaque]
+            #[diplomat::opaque_mut]
             pub struct $vec_name(Vec<$ty>);
 
             impl $vec_name {
@@ -174,7 +174,7 @@ pub mod ffi {
         }
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::cfg(supports = iterators)]
     pub struct MyIterator<'a>(std::slice::Iter<'a, u8>);
     impl<'a> MyIterator<'a> {
@@ -207,7 +207,7 @@ pub mod ffi {
         }
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::cfg(supports = iterators)]
     struct OpaqueIterator<'a>(Box<dyn Iterator<Item = AttrOpaque1> + 'a>);
     impl<'a> OpaqueIterator<'a> {
@@ -233,7 +233,7 @@ pub mod ffi {
         }
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::cfg(supports = iterators)]
     struct OpaqueRefIterator<'a>(std::slice::Iter<'a, AttrOpaque1>);
     impl<'a> OpaqueRefIterator<'a> {
@@ -243,7 +243,7 @@ pub mod ffi {
         }
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::cfg(supports = arithmetic)]
     pub(crate) struct OpaqueArithmetic {
         x: i32,
@@ -514,7 +514,7 @@ pub mod ffi {
     pub struct FeatureTest();
 
     #[diplomat::attr(not(nanobind), disable)]
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     /// Tests for https://github.com/rust-diplomat/diplomat/issues/1050.
     /// C++ generates unique_ptrs for Opaque ZSTs, and Nanobind
     /// expects every unique_ptr it converts to wrap a unique pointer type. It errors otherwise.

--- a/feature_tests/src/callbacks.rs
+++ b/feature_tests/src/callbacks.rs
@@ -156,7 +156,7 @@ mod ffi {
     }
 
     #[diplomat::cfg(supports = "callbacks")]
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     pub struct MutableCallbackHolder {
         held: Box<dyn FnMut(i32) -> i32>,
     }

--- a/feature_tests/src/lifetimes.rs
+++ b/feature_tests/src/lifetimes.rs
@@ -334,7 +334,7 @@ pub mod ffi {
         }
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     pub struct OpaqueThinIter<'a>(pub std::slice::Iter<'a, crate::lifetimes::Internal>);
 
     impl<'a> OpaqueThinIter<'a> {

--- a/feature_tests/src/result.rs
+++ b/feature_tests/src/result.rs
@@ -1,7 +1,7 @@
 #[diplomat::bridge]
 pub mod ffi {
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     #[diplomat::attr(auto, error)]
     pub struct ResultOpaque(i32);
 

--- a/feature_tests/src/slices.rs
+++ b/feature_tests/src/slices.rs
@@ -3,7 +3,7 @@ pub mod ffi {
     use diplomat_runtime::{DiplomatStr, DiplomatStrSlice, DiplomatWrite};
     use std::fmt::Write as _;
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     pub struct MyString(String);
 
     impl MyString {
@@ -50,7 +50,7 @@ pub mod ffi {
         }
     }
 
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     struct Float64Vec(Vec<f64>);
 
     impl Float64Vec {

--- a/feature_tests/src/structs.rs
+++ b/feature_tests/src/structs.rs
@@ -507,7 +507,7 @@ pub mod ffi {
     }
 
     #[diplomat::cfg(supports=abi_compatibles)]
-    #[diplomat::opaque]
+    #[diplomat::opaque_mut]
     pub struct PrimitiveStructVec(Vec<PrimitiveStruct>);
 
     impl PrimitiveStructVec {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -437,7 +437,7 @@ impl AttributeInfo {
             } else if ident == "diplomat" {
                 if attr.path().segments.len() == 2 {
                     let seg = &attr.path().segments.iter().nth(1).unwrap().ident;
-                    if seg == "opaque" {
+                    if seg == "opaque" || seg == "opaque_mut" {
                         opaque = true;
                         return false;
                     } else if seg == "out" {
@@ -461,7 +461,7 @@ impl AttributeInfo {
                     } else if seg == "config" {
                         panic!("#[diplomat::config] is restricted to top level types in lib.rs.");
                     } else {
-                        panic!("Only #[diplomat::opaque] and #[diplomat::rust_link] are supported: {seg:?}")
+                        panic!("Only #[diplomat::opaque], #[diplomat::opaque_mut], and #[diplomat::rust_link] are supported: {seg:?}")
                     }
                 } else {
                     panic!("#[diplomat::foo] attrs have a single-segment path name")
@@ -788,7 +788,7 @@ macro_rules! expose_attrs {
     }
 }
 
-expose_attrs! {opaque, attr, demo}
+expose_attrs! {opaque, opaque_mut, attr, demo}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This is progress on https://github.com/rust-diplomat/diplomat/issues/225

This will cause tool failures on previously working Diplomat code; but it mostly requires adding an annotation.

This is the easy part of #225. The hard part is making sure these types never get borrowed in a persisted way. This might become a huge pain for iterators.