### PR TITLE
Nanobind Disable List Optional Comparisons for Bound Vectors  (#1149)

### DIFF
--- a/core/src/hir/attrs.rs
+++ b/core/src/hir/attrs.rs
@@ -351,6 +351,7 @@ impl SpecialMethod {
 #[non_exhaustive]
 pub struct SpecialMethodPresence {
     pub comparator: bool,
+    pub optional_comparator: bool,
     /// If it is an iterator, the type it iterates over
     pub iterator: Option<SuccessType>,
     /// If it is an iterable, the iterator type it returns (*not* the type it iterates over,
@@ -851,7 +852,7 @@ impl Attrs {
                             ));
                         }
                     }
-                    SpecialMethod::Comparison(_) => {
+                    SpecialMethod::Comparison(optional) => {
                         check_param_count("Comparator", 1, errors);
                         if special_method_presence.comparator {
                             errors.push(LoweringError::Other(
@@ -859,6 +860,7 @@ impl Attrs {
                             ));
                         }
                         special_method_presence.comparator = true;
+                        special_method_presence.optional_comparator = *optional;
                         // In the long run we can actually support heterogeneous comparators. Not a priority right now.
                         const COMPARATOR_ERROR: &str =
                             "Comparator's parameter must be identical to self";

--- a/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
+++ b/core/src/hir/snapshots/diplomat_core__hir__elision__tests__simple_mod.snap
@@ -232,6 +232,7 @@ TypeContext {
             },
             special_method_presence: SpecialMethodPresence {
                 comparator: false,
+                optional_comparator: false,
                 iterator: None,
                 iterable: None,
             },
@@ -501,6 +502,7 @@ TypeContext {
             },
             special_method_presence: SpecialMethodPresence {
                 comparator: false,
+                optional_comparator: false,
                 iterator: None,
                 iterable: None,
             },
@@ -556,6 +558,7 @@ TypeContext {
             },
             special_method_presence: SpecialMethodPresence {
                 comparator: false,
+                optional_comparator: false,
                 iterator: None,
                 iterable: None,
             },

--- a/feature_tests/cpp/include/ns/RenamedPartialComparableSlice.d.hpp
+++ b/feature_tests/cpp/include/ns/RenamedPartialComparableSlice.d.hpp
@@ -1,0 +1,70 @@
+#ifndef SOMELIB_ns_RenamedPartialComparableSlice_D_HPP
+#define SOMELIB_ns_RenamedPartialComparableSlice_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+namespace somelib {
+namespace ns {
+struct RenamedPartialComparableSlice;
+} // namespace ns
+} // namespace somelib
+
+
+
+namespace somelib::ns {
+namespace capi {
+    struct RenamedPartialComparableSlice {
+      float f;
+    };
+
+    typedef struct RenamedPartialComparableSlice_option {union { RenamedPartialComparableSlice ok; }; bool is_ok; } RenamedPartialComparableSlice_option;
+    typedef struct DiplomatRenamedPartialComparableSliceView {
+      const RenamedPartialComparableSlice* data;
+      size_t len;
+    } DiplomatRenamedPartialComparableSliceView;
+
+    typedef struct DiplomatRenamedPartialComparableSliceViewMut {
+      RenamedPartialComparableSlice* data;
+      size_t len;
+    } DiplomatRenamedPartialComparableSliceViewMut;
+} // namespace capi
+} // namespace
+
+
+namespace somelib::ns {
+struct RenamedPartialComparableSlice {
+    float f;
+
+  inline std::optional<int8_t> partial_cmp(const somelib::ns::RenamedPartialComparableSlice& other) const;
+
+  inline std::optional<bool> operator==(const somelib::ns::RenamedPartialComparableSlice& other) const;
+  inline std::optional<bool> operator!=(const somelib::ns::RenamedPartialComparableSlice& other) const;
+  inline std::optional<bool> operator<=(const somelib::ns::RenamedPartialComparableSlice& other) const;
+  inline std::optional<bool> operator>=(const somelib::ns::RenamedPartialComparableSlice& other) const;
+  inline std::optional<bool> operator<(const somelib::ns::RenamedPartialComparableSlice& other) const;
+  inline std::optional<bool> operator>(const somelib::ns::RenamedPartialComparableSlice& other) const;
+
+    inline somelib::ns::capi::RenamedPartialComparableSlice AsFFI() const;
+    inline static somelib::ns::RenamedPartialComparableSlice FromFFI(somelib::ns::capi::RenamedPartialComparableSlice c_struct);
+};
+
+} // namespace
+namespace somelib::diplomat {
+    template<typename T>
+    struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<const somelib::ns::RenamedPartialComparableSlice>>>> {
+        using type = somelib::ns::capi::DiplomatRenamedPartialComparableSliceView;
+    };
+
+    template<typename T>
+    struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<somelib::ns::RenamedPartialComparableSlice>>>> {
+        using type = somelib::ns::capi::DiplomatRenamedPartialComparableSliceViewMut;
+};
+}
+#endif // SOMELIB_ns_RenamedPartialComparableSlice_D_HPP

--- a/feature_tests/cpp/include/ns/RenamedPartialComparableSlice.hpp
+++ b/feature_tests/cpp/include/ns/RenamedPartialComparableSlice.hpp
@@ -1,0 +1,77 @@
+#ifndef SOMELIB_ns_RenamedPartialComparableSlice_HPP
+#define SOMELIB_ns_RenamedPartialComparableSlice_HPP
+
+#include "RenamedPartialComparableSlice.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+
+namespace somelib::ns {
+namespace capi {
+    extern "C" {
+
+    typedef struct namespace_PartialComparableSlice_partial_cmp_result {union {int8_t ok; }; bool is_ok;} namespace_PartialComparableSlice_partial_cmp_result;
+    namespace_PartialComparableSlice_partial_cmp_result namespace_PartialComparableSlice_partial_cmp(const somelib::ns::capi::RenamedPartialComparableSlice* self, const somelib::ns::capi::RenamedPartialComparableSlice* other);
+
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::optional<int8_t> somelib::ns::RenamedPartialComparableSlice::partial_cmp(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto result = somelib::ns::capi::namespace_PartialComparableSlice_partial_cmp(reinterpret_cast<const somelib::ns::capi::RenamedPartialComparableSlice*>(this),
+        reinterpret_cast<const somelib::ns::capi::RenamedPartialComparableSlice*>(&other));
+    return result.is_ok ? std::optional<int8_t>(result.ok) : std::nullopt;
+}
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator==(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() == 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator!=(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() != 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator<=(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() <= 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator>=(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() >= 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator<(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() < 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator>(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() > 0;
+}
+
+
+inline somelib::ns::capi::RenamedPartialComparableSlice somelib::ns::RenamedPartialComparableSlice::AsFFI() const {
+    return somelib::ns::capi::RenamedPartialComparableSlice {
+        /* .f = */ f,
+    };
+}
+
+inline somelib::ns::RenamedPartialComparableSlice somelib::ns::RenamedPartialComparableSlice::FromFFI(somelib::ns::capi::RenamedPartialComparableSlice c_struct) {
+    return somelib::ns::RenamedPartialComparableSlice {
+        /* .f = */ c_struct.f,
+    };
+}
+
+
+#endif // SOMELIB_ns_RenamedPartialComparableSlice_HPP

--- a/feature_tests/nanobind/src/include/ns/RenamedPartialComparableSlice.d.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedPartialComparableSlice.d.hpp
@@ -1,0 +1,70 @@
+#ifndef SOMELIB_ns_RenamedPartialComparableSlice_D_HPP
+#define SOMELIB_ns_RenamedPartialComparableSlice_D_HPP
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+namespace somelib {
+namespace ns {
+struct RenamedPartialComparableSlice;
+} // namespace ns
+} // namespace somelib
+
+
+
+namespace somelib::ns {
+namespace capi {
+    struct RenamedPartialComparableSlice {
+      float f;
+    };
+
+    typedef struct RenamedPartialComparableSlice_option {union { RenamedPartialComparableSlice ok; }; bool is_ok; } RenamedPartialComparableSlice_option;
+    typedef struct DiplomatRenamedPartialComparableSliceView {
+      const RenamedPartialComparableSlice* data;
+      size_t len;
+    } DiplomatRenamedPartialComparableSliceView;
+
+    typedef struct DiplomatRenamedPartialComparableSliceViewMut {
+      RenamedPartialComparableSlice* data;
+      size_t len;
+    } DiplomatRenamedPartialComparableSliceViewMut;
+} // namespace capi
+} // namespace
+
+
+namespace somelib::ns {
+struct RenamedPartialComparableSlice {
+    float f;
+
+  inline std::optional<int8_t> partial_cmp(const somelib::ns::RenamedPartialComparableSlice& other) const;
+
+  inline std::optional<bool> operator==(const somelib::ns::RenamedPartialComparableSlice& other) const;
+  inline std::optional<bool> operator!=(const somelib::ns::RenamedPartialComparableSlice& other) const;
+  inline std::optional<bool> operator<=(const somelib::ns::RenamedPartialComparableSlice& other) const;
+  inline std::optional<bool> operator>=(const somelib::ns::RenamedPartialComparableSlice& other) const;
+  inline std::optional<bool> operator<(const somelib::ns::RenamedPartialComparableSlice& other) const;
+  inline std::optional<bool> operator>(const somelib::ns::RenamedPartialComparableSlice& other) const;
+
+    inline somelib::ns::capi::RenamedPartialComparableSlice AsFFI() const;
+    inline static somelib::ns::RenamedPartialComparableSlice FromFFI(somelib::ns::capi::RenamedPartialComparableSlice c_struct);
+};
+
+} // namespace
+namespace somelib::diplomat {
+    template<typename T>
+    struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<const somelib::ns::RenamedPartialComparableSlice>>>> {
+        using type = somelib::ns::capi::DiplomatRenamedPartialComparableSliceView;
+    };
+
+    template<typename T>
+    struct diplomat_c_span_convert<T, std::enable_if_t<std::is_same_v<T, span<somelib::ns::RenamedPartialComparableSlice>>>> {
+        using type = somelib::ns::capi::DiplomatRenamedPartialComparableSliceViewMut;
+};
+}
+#endif // SOMELIB_ns_RenamedPartialComparableSlice_D_HPP

--- a/feature_tests/nanobind/src/include/ns/RenamedPartialComparableSlice.hpp
+++ b/feature_tests/nanobind/src/include/ns/RenamedPartialComparableSlice.hpp
@@ -1,0 +1,77 @@
+#ifndef SOMELIB_ns_RenamedPartialComparableSlice_HPP
+#define SOMELIB_ns_RenamedPartialComparableSlice_HPP
+
+#include "RenamedPartialComparableSlice.d.hpp"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <cstdlib>
+#include "../diplomat_runtime.hpp"
+
+
+namespace somelib::ns {
+namespace capi {
+    extern "C" {
+
+    typedef struct namespace_PartialComparableSlice_partial_cmp_result {union {int8_t ok; }; bool is_ok;} namespace_PartialComparableSlice_partial_cmp_result;
+    namespace_PartialComparableSlice_partial_cmp_result namespace_PartialComparableSlice_partial_cmp(const somelib::ns::capi::RenamedPartialComparableSlice* self, const somelib::ns::capi::RenamedPartialComparableSlice* other);
+
+    } // extern "C"
+} // namespace capi
+} // namespace
+
+inline std::optional<int8_t> somelib::ns::RenamedPartialComparableSlice::partial_cmp(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto result = somelib::ns::capi::namespace_PartialComparableSlice_partial_cmp(reinterpret_cast<const somelib::ns::capi::RenamedPartialComparableSlice*>(this),
+        reinterpret_cast<const somelib::ns::capi::RenamedPartialComparableSlice*>(&other));
+    return result.is_ok ? std::optional<int8_t>(result.ok) : std::nullopt;
+}
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator==(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() == 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator!=(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() != 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator<=(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() <= 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator>=(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() >= 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator<(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() < 0;
+}
+
+inline std::optional<bool> somelib::ns::RenamedPartialComparableSlice::operator>(const somelib::ns::RenamedPartialComparableSlice& other) const {
+    auto val = this->partial_cmp(other);
+    if (!val.has_value()) { return std::nullopt; } return val.value() > 0;
+}
+
+
+inline somelib::ns::capi::RenamedPartialComparableSlice somelib::ns::RenamedPartialComparableSlice::AsFFI() const {
+    return somelib::ns::capi::RenamedPartialComparableSlice {
+        /* .f = */ f,
+    };
+}
+
+inline somelib::ns::RenamedPartialComparableSlice somelib::ns::RenamedPartialComparableSlice::FromFFI(somelib::ns::capi::RenamedPartialComparableSlice c_struct) {
+    return somelib::ns::RenamedPartialComparableSlice {
+        /* .f = */ c_struct.f,
+    };
+}
+
+
+#endif // SOMELIB_ns_RenamedPartialComparableSlice_HPP

--- a/feature_tests/nanobind/src/somelib_ext.cpp
+++ b/feature_tests/nanobind/src/somelib_ext.cpp
@@ -78,6 +78,7 @@ void add_Nested_binding(nb::module_);
 }namespace somelib::ns{
   
 void add_RenamedDeprecatedStruct_binding(nb::module_);
+void add_RenamedPartialComparableSlice_binding(nb::module_);
 void add_RenamedRenamedCachedIncludeZST_binding(nb::module_);
 void add_RenamedStructWithAttrs_binding(nb::module_);
 void add_RenamedTestMacroStruct_binding(nb::module_);
@@ -235,6 +236,7 @@ NB_MODULE(somelib, mod)
     nested::ns2::add_Nested_binding(nested_ns2_mod);
     
     ns::add_RenamedDeprecatedStruct_binding(ns_mod);
+    ns::add_RenamedPartialComparableSlice_binding(ns_mod);
     ns::add_RenamedRenamedCachedIncludeZST_binding(ns_mod);
     ns::add_RenamedStructWithAttrs_binding(ns_mod);
     ns::add_RenamedTestMacroStruct_binding(ns_mod);

--- a/feature_tests/nanobind/src/sub_modules/somelib/ns/RenamedPartialComparableSlice_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/somelib/ns/RenamedPartialComparableSlice_binding.cpp
@@ -1,0 +1,28 @@
+#include "diplomat_nanobind_common.hpp"
+
+
+#include "ns/RenamedPartialComparableSlice.hpp"
+NB_MAKE_OPAQUE(std::vector<somelib::ns::RenamedPartialComparableSlice>)
+namespace nanobind::detail { template<> struct is_equality_comparable<somelib::ns::RenamedPartialComparableSlice>{static constexpr bool value = false;}; }
+
+namespace somelib::ns {
+void add_RenamedPartialComparableSlice_binding(nb::module_ mod) {
+    
+    // Python lists are represented as PyObject**, which runs somewhat counter to any use cases where we want to be able to transparently pass over lists without copying over memory in any ways.
+    // bind_vector solves this issue by exposing std::vector<somelib::ns::RenamedPartialComparableSlice> as a type that will exist inside of C++, with functions to access its memory from Python.
+    // TL;DR: this creates a faux list type that makes it easier to pass vectors of this type in Python without copying. 
+    nb::bind_vector<std::vector<somelib::ns::RenamedPartialComparableSlice>>(mod, "RenamedPartialComparableSliceSlice"); 
+    nb::class_<somelib::ns::RenamedPartialComparableSlice> st(mod, "RenamedPartialComparableSlice");
+    st
+        .def(nb::init<>())
+        .def(nb::init<float>(), "f"_a.none())
+        .def_rw("f", &somelib::ns::RenamedPartialComparableSlice::f)
+        .def(nb::self == nb::self)
+            .def(nb::self != nb::self)
+            .def(nb::self <= nb::self)
+            .def(nb::self >= nb::self)
+            .def(nb::self < nb::self)
+            .def(nb::self > nb::self);
+}
+
+} 

--- a/feature_tests/src/attrs.rs
+++ b/feature_tests/src/attrs.rs
@@ -189,6 +189,19 @@ pub mod ffi {
         }
     }
 
+    #[diplomat::attr(auto, abi_compatible)]
+    #[diplomat::cfg(supports = partial_comparators)]
+    pub struct PartialComparableSlice {
+        f: f32,
+    }
+
+    impl PartialComparableSlice {
+        #[diplomat::attr(auto, comparison)]
+        pub fn partial_cmp(&self, other: &PartialComparableSlice) -> Option<core::cmp::Ordering> {
+            self.f.partial_cmp(&other.f)
+        }
+    }
+
     #[diplomat::opaque]
     #[diplomat::cfg(supports = indexing)]
     pub struct MyIndexer(Vec<String>);

--- a/tool/src/nanobind/gen.rs
+++ b/tool/src/nanobind/gen.rs
@@ -264,6 +264,11 @@ impl<'ccx, 'tcx: 'ccx> ItemGenContext<'ccx, 'tcx> {
         if def.attrs.abi_compatible {
             write!(binding_prefix, "NB_MAKE_OPAQUE(std::vector<{type_name}>)")
                 .expect("Could not write to header.");
+            if def.special_method_presence.comparator {
+                // Bound vectors of types that return `std::optional<bool>` doesn't work for GCC. See https://github.com/rust-diplomat/diplomat/issues/1148
+                // TODO: At some point we should just re-write the vector binding ourselves instead of having to sidestep this.
+                write!(binding_prefix, "\nnamespace nanobind::detail {{ template<> struct is_equality_comparable<{type_name}>{{static constexpr bool value = false;}}; }}").expect("Could not write to header");
+            }
         }
 
         ImplTemplate {


### PR DESCRIPTION
A quick and dirty fix for
https://github.com/rust-diplomat/diplomat/issues/1148. I think a more robust solution will be to eventually make our own bound vector type, but this will work for now (all this really does is disable `__contains__`, `count`, and `remove` for vectors of optional types that implement only partial comparisons.)