### PR TITLE
nanobind: emit lifetime annotations on read-only getters

### DIFF
--- a/feature_tests/nanobind/src/sub_modules/somelib/Bar_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/somelib/Bar_binding.cpp
@@ -12,7 +12,7 @@ void add_Bar_binding(nb::module_ mod) {
     
     nb::class_<somelib::Bar> opaque(mod, "Bar", nb::type_slots(somelib_Bar_slots));
     opaque
-        .def_prop_ro("foo", &somelib::Bar::foo);
+        .def_prop_ro("foo", &somelib::Bar::foo, nb::rv_policy::reference_internal);
 }
 
 } 

--- a/feature_tests/nanobind/src/sub_modules/somelib/Foo_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/somelib/Foo_binding.cpp
@@ -16,7 +16,7 @@ void add_Foo_binding(nb::module_ mod) {
     opaque
         .def(nb::new_(std::move(maybe_op_unwrap(&somelib::Foo::new_))), "x"_a, nb::keep_alive<1, 2>())
         .def("as_returning", &somelib::Foo::as_returning, nb::keep_alive<0, 1>())
-        .def_prop_ro("bar", std::move(maybe_op_unwrap(&somelib::Foo::get_bar)))
+        .def_prop_ro("bar", std::move(maybe_op_unwrap(&somelib::Foo::get_bar)), nb::keep_alive<0, 1>())
         .def_static("extract_from_bounds", std::move(maybe_op_unwrap(&somelib::Foo::extract_from_bounds)), "bounds"_a, "another_string"_a, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>(), "Test that the extraction logic correctly pins the right fields")
         .def_static("extract_from_fields", std::move(maybe_op_unwrap(&somelib::Foo::extract_from_fields)), "fields"_a, nb::keep_alive<0, 1>())
         .def_static("new_static", std::move(maybe_op_unwrap(&somelib::Foo::new_static)), "x"_a);

--- a/feature_tests/nanobind/src/sub_modules/somelib/OpaqueThinVec_binding.cpp
+++ b/feature_tests/nanobind/src/sub_modules/somelib/OpaqueThinVec_binding.cpp
@@ -14,7 +14,7 @@ void add_OpaqueThinVec_binding(nb::module_ mod) {
     opaque
         .def("__len__", &somelib::OpaqueThinVec::__len__)
         .def(nb::new_(std::move(maybe_op_unwrap(&somelib::OpaqueThinVec::create))), "a"_a, "b"_a, "c"_a)
-        .def_prop_ro("first", &somelib::OpaqueThinVec::first)
+        .def_prop_ro("first", &somelib::OpaqueThinVec::first, nb::rv_policy::reference_internal)
         .def("__getitem__", [](somelib::OpaqueThinVec* self, size_t index) {
                 auto out = self->operator[] (index);
                 if (out == nullptr) {

--- a/tool/templates/nanobind/method_impl.cpp.jinja
+++ b/tool/templates/nanobind/method_impl.cpp.jinja
@@ -59,6 +59,10 @@
                     {%- for p in m.param_decls.params -%}{%- if !loop.first -%}, {% endif -%}{{p.name}}{%- endfor -%}); }
             {%- endif -%}
             {{- method_params::params(m.method.params, m.lifetime_args) }}
+        {%- else -%}
+            {#- Read-only getters still need their keep_alive/rv_policy annotations: a getter
+                returning a borrowed view must keep self alive while the view exists. -#}
+            {%- if let Some(lifetime_args) = m.lifetime_args %}, {{lifetime_args}}{% endif %}
         {%- endif -%}
         {%- if let Some(doc) = m.docstring %}, {{doc}}{% endif -%})
     {%- when crate::hir::SpecialMethod::Constructor -%}


### PR DESCRIPTION
## Summary

The `Getter` branch of `tool/templates/nanobind/method_impl.cpp.jinja` only rendered `lifetime_args` (the computed `nb::keep_alive<...>` / `nb::rv_policy::...` annotations) when a matching setter existed. Read-only getters (`def_prop_ro`) silently dropped them.

A getter returning a borrowed view — e.g. an opaque borrowing from `self` — therefore produced a Python object with no ownership edge back to its owner. Once the owner was garbage-collected, the view dangled and attribute reads returned freed memory.

Downstream impact (how this was found): in reactor-repo, `ZBComponent.component` returns a `DynZerobuf` view into the component's owned buffer. Post-run sim tests that stored `.component` views (or dropped the entry temporary before reading) read garbage — out-of-range enum discriminants, nondeterministic integers — with allocator-dependent reproducibility (failed on one machine, passed on another).

## Change

- Render `lifetime_args` in the getter-only branch, matching what plain methods and getter+setter properties already do.
- Regenerate the nanobind feature-test bindings: `Bar.foo` and `OpaqueThinVec.first` gain `nb::rv_policy::reference_internal`, `Foo.bar` gains `nb::keep_alive<0, 1>`.

## Testing

- `cargo make`-equivalent regeneration of feature tests (`diplomat-tool nanobind`) — only the three expected files changed.
- Nanobind feature tests: 34 passed.
- Verified in reactor-repo (with this rev path-overridden) that the regenerated `ZBComponent_binding.cpp` gains `keep_alive<0, 1>` on `component`, the previously-dangling read patterns return correct data, and the failing `SmokeTestLocal` integration run passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)